### PR TITLE
*/action.yml: action fails if ~/go/bin does not exist: mkdir it

### DIFF
--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -45,7 +45,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        [ ! -f "~/go/bin/build-docker" ] && curl -L https://github.com/upfluence/actions/releases/latest/download/build-docker > ~/go/bin/build-docker
+        [ ! -f "~/go/bin/build-docker" ] && mkdir -p ~/go/bin && curl -L https://github.com/upfluence/actions/releases/latest/download/build-docker > ~/go/bin/build-docker
       shell: bash
     - run: chmod +x ~/go/bin/build-docker
       shell: bash

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        [ ! -f "~/go/bin/bump-version" ] && curl -L https://github.com/upfluence/actions/releases/latest/download/bump-version > ~/go/bin/bump-version
+        [ ! -f "~/go/bin/bump-version" ] && mkdir -p ~/go/bin && curl -L https://github.com/upfluence/actions/releases/latest/download/bump-version > ~/go/bin/bump-version
       shell: bash
     - run: chmod +x ~/go/bin/bump-version
       shell: bash

--- a/compile-go/action.yml
+++ b/compile-go/action.yml
@@ -44,7 +44,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        [ ! -f "~/go/bin/compile-go" ] && curl -L https://github.com/upfluence/actions/releases/latest/download/compile-go > ~/go/bin/compile-go
+        [ ! -f "~/go/bin/compile-go" ] && mkdir -p ~/go/bin && curl -L https://github.com/upfluence/actions/releases/latest/download/compile-go > ~/go/bin/compile-go
       shell: bash
     - run: chmod +x ~/go/bin/compile-go
       shell: bash

--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -16,7 +16,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        [ ! -f "~/go/bin/create-github-release" ] && curl -L https://github.com/upfluence/actions/releases/latest/download/create-github-release > ~/go/bin/create-github-release
+        [ ! -f "~/go/bin/create-github-release" ] && mkdir -p ~/go/bin && curl -L https://github.com/upfluence/actions/releases/latest/download/create-github-release > ~/go/bin/create-github-release
       shell: bash
     - run: chmod +x ~/go/bin/create-github-release
       shell: bash

--- a/publish-cli/action.yml
+++ b/publish-cli/action.yml
@@ -32,7 +32,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        [ ! -f "~/go/bin/publish-cli" ] && curl -L https://github.com/upfluence/actions/releases/latest/download/publish-cli > ~/go/bin/publish-cli
+        [ ! -f "~/go/bin/publish-cli" ] && mkdir -p ~/go/bin && curl -L https://github.com/upfluence/actions/releases/latest/download/publish-cli > ~/go/bin/publish-cli
       shell: bash
     - run: chmod +x ~/go/bin/publish-cli
       shell: bash

--- a/update-homebrew-formula/action.yml
+++ b/update-homebrew-formula/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        [ ! -f "~/go/bin/update-homebrew-formula" ] && curl -L https://github.com/upfluence/actions/releases/latest/download/update-homebrew-formula > ~/go/bin/update-homebrew-formula
+        [ ! -f "~/go/bin/update-homebrew-formula" ] && mkdir -p ~/go/bin && curl -L https://github.com/upfluence/actions/releases/latest/download/update-homebrew-formula > ~/go/bin/update-homebrew-formula
       shell: bash
     - run: chmod +x ~/go/bin/update-homebrew-formula
       shell: bash


### PR DESCRIPTION
### What does this PR do?

- Actions fail if `setup-go` was not called on the runner machine beforehand
- This aims to circumvent this issue and should not interfere with an existing `~/go/bin` directory

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
