### PR TITLE
.github/workflows/*: use ubuntu-24.04; compile-go: allow for input of build tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
@@ -28,7 +28,7 @@ jobs:
         run: go test -v ./...
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: test
     permissions:
       contents: write

--- a/.github/workflows/cli-go-compile.yml
+++ b/.github/workflows/cli-go-compile.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     if: contains('refs/heads/master', github.ref)
     steps:
       - name: Setup Go (Upfluence)

--- a/.github/workflows/lib-any-release.yml
+++ b/.github/workflows/lib-any-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   lint:
     name: runner / golangci-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Install Go

--- a/compile-go/action.yml
+++ b/compile-go/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Go template of the executable'
     required: false
     default: '{{ .Name }}'
+  compiler-tags:
+    description: '[CSV] List of build tags to pass to go build'
+    required: false
+    default: ''
 outputs:
   definitions:
     description: 'definitions'
@@ -51,5 +55,5 @@ runs:
     - run: mkdir -p ${{ inputs.dist-dir }}
       shell: bash
     - id: compile-go
-      run: ~/go/bin/compile-go --executable-paths ${{ inputs.executable-paths }} --release-version ${{ inputs.version }} --dist-dir '${{ inputs.dist-dir }}' --oss ${{ inputs.os }} --archs ${{ inputs.arch }} --cgo ${{ inputs.cgo }} --linker-mode ${{ inputs.linker-mode }} --additional-links '${{ inputs.additional-links }}' --name-template '${{ inputs.name-template }}'
+      run: ~/go/bin/compile-go --executable-paths ${{ inputs.executable-paths }} --release-version ${{ inputs.version }} --dist-dir '${{ inputs.dist-dir }}' --oss ${{ inputs.os }} --archs ${{ inputs.arch }} --cgo ${{ inputs.cgo }} --linker-mode ${{ inputs.linker-mode }} --additional-links '${{ inputs.additional-links }}' --name-template '${{ inputs.name-template }}' --compiler-tags '${{ inputs.compiler-tags }}'
       shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upfluence/actions
 
-go 1.20
+go 1.22
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -224,6 +225,7 @@ google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=


### PR DESCRIPTION
### What does this PR do?

- Bump to go 1.22
- Bump to ubuntu-24.04
- Allow caller to pass compiler tags to compile-go, such as timetzdata

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
