### PR TITLE
bump-verison: Add pre releasing bumping on staging

### DIFF
--- a/bump-version/bump.go
+++ b/bump-version/bump.go
@@ -15,6 +15,7 @@ const (
 	bumpPatch
 	bumpMinor
 	bumpMajor
+	bumpPre
 )
 
 var (
@@ -23,12 +24,13 @@ var (
 		"bump_patch": bumpPatch,
 		"bump_minor": bumpMinor,
 		"bump_major": bumpMajor,
+		"bump_pre":   bumpPre,
 	}
 
 	defaultStrategyByBranch = map[string]strategy{
 		"master":  bumpPatch,
 		"main":    bumpPatch,
-		"staging": bumpRC,
+		"staging": bumpPre,
 		"qa":      bumpRC,
 	}
 )
@@ -56,6 +58,8 @@ func (s strategy) inc(v *version) {
 		v.IncMinor()
 	case bumpMajor:
 		v.IncMajor()
+	case bumpPre:
+		v.IncPre()
 	}
 }
 

--- a/bump-version/version.go
+++ b/bump-version/version.go
@@ -22,6 +22,22 @@ func parse(t string) (*version, error) {
 	return &version{Version: *v}, nil
 }
 
+func (v *version) Pre() int64 {
+	r := v.Metadata()
+
+	if r == "" {
+		return 0
+	}
+
+	res, err := strconv.Atoi(strings.TrimPrefix(r, "pre"))
+
+	if err != nil {
+		return 0
+	}
+
+	return int64(res)
+}
+
 func (v *version) RC() int64 {
 	r := v.Prerelease()
 
@@ -67,12 +83,23 @@ func (v *version) IncPatch() {
 	v.Version = v.Version.IncPatch()
 }
 
+func (v *version) IncPre() {
+	pre := v.Pre()
+
+	if pre == 0 {
+		v.IncRC()
+	}
+
+	v.Version, _ = v.SetMetadata(fmt.Sprintf("pre%d", pre+1))
+}
+
 func (v *version) IncRC() {
 	if v.RC() == 0 {
 		v.IncPatch()
 	}
 
 	v.Version, _ = v.SetPrerelease(fmt.Sprintf("rc%d", v.RC()+1))
+	v.Version, _ = v.SetMetadata("")
 }
 
 func incrementVersionFromCommits(v *version, messages []string) bool {

--- a/bump-version/version_test.go
+++ b/bump-version/version_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrategy(t *testing.T) {
+	for _, tt := range []struct {
+		have     string
+		strategy strategy
+
+		want string
+	}{
+		{
+			have:     "v0.0.0",
+			strategy: bumpRC,
+			want:     "v0.0.1-rc1",
+		},
+		{
+			have:     "v0.0.0",
+			strategy: bumpPre,
+			want:     "v0.0.1-rc1+pre1",
+		},
+		{
+			have:     "v0.0.1-rc1+pre1",
+			strategy: bumpRC,
+			want:     "v0.0.1-rc2",
+		},
+		{
+			have:     "v0.0.1-rc1+pre1",
+			strategy: bumpMajor,
+			want:     "v1.0.0",
+		},
+	} {
+		v, err := parse(tt.have)
+		require.NoError(t, err)
+
+		tt.strategy.inc(v)
+
+		assert.Equal(t, tt.want, v.String())
+	}
+}


### PR DESCRIPTION
### What does this PR do?

At the dawn of our new environment deployment. We dont have a good way to differentiate staging version and QA version.

This patch put in place a new scheme that uses sequential `+pre` suffix to differential staging version. `-rc` suffix is now dedicated to the QA env.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
