### PR TITLE
compile: Add "-extldflags "-static"" ldFlags when cgo enabled

### DIFF
--- a/compile-go/compile.go
+++ b/compile-go/compile.go
@@ -250,6 +250,8 @@ func (c *compiler) execute(ctx context.Context, b build, cctx toolkit.CommandCon
 
 	if c.cgo {
 		cgoStr = "1"
+
+		ldFlags = append(ldFlags, "-extldflags \"-static\"")
 	}
 
 	filename := filepath.Join(c.distDir, t)


### PR DESCRIPTION
### What does this PR do?

Force the statics linking in case of cgo enabled.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Appends `-extldflags "-static"` to `-ldflags` when `CGO_ENABLED=1` to force static linking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9cb5190e9b528c6a7523e3ef71d0ca43c089aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->